### PR TITLE
fix docker image arch issue

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,30 +2,108 @@ include Makefile.base
 
 VERSION = 1.4.1
 RELEASE_DIR = $(abspath ${DIST_DIR}/release/${VERSION})
+ALL_PLATFORM=linux/amd64,linux/arm64,linux/arm/v7
 
-fn-test-dcinja-linux-amd64 = docker run --rm -v `pwd`/${DIST_DIR}:/app $(1) sh -c "echo \"Normal: {{ name }}\" | /app/linux-amd64/dcinja -j '{\"name\": \"$(1)\"}'"
-fn-test-dcinja-alpine = docker run --rm -v `pwd`/${DIST_DIR}:/app $(1) sh -c "echo \"Normal: {{ name }}\" | /app/alpine/dcinja -j '{\"name\": \"$(1)\"}'"
+# release images and related arch as below
+# format as <image-name>:<tag-name>
+#           + arch-1
+#           + arch-2
+#           ...
+#
+### glibc
+# dcinja:latest
+#   + linux/amd64
+#   + linux/arm64
+#   + linux/arm/v7
+# dcinja:1.x
+#   + linux/amd64
+#   + linux/arm64
+#   + linux/arm/v7
+#
+### alpine
+# dcinja:latest-alpine
+#   + linux/amd64
+#   + linux/arm64
+#   + linux/arm/v7
+# dcinja:1.x-alpine
+#   + linux/amd64
+#   + linux/arm64
+#   + linux/arm/v7
+
+fn-test-dcinja = \
+    export lib="$(1)" \
+    && export platform="$(2)" \
+    && export image="$(3)" \
+    \
+    && docker run \
+        --rm \
+        --platform=$${platform} \
+        -v `pwd`/${DIST_DIR}/$${lib}/$${platform}:/app \
+        $${image} \
+        sh -c "echo \"Normal: {{ name }}\" \
+            | /app/dcinja -j '{\"name\": \"$${image}\"}'"
+
+fn-build-dcinja = \
+    export lib="$(1)" \
+    && export platform="$(2)" \
+    && export tag="$(3)" \
+    && export dockerfile="$(4)" \
+    && export dist="$(DIST_DIR)/$${lib}/$${platform}" \
+    \
+    && mkdir -p $${dist} \
+	&& docker buildx build \
+	    --platform=$${platform} \
+	    --tag dcinja:$${tag} \
+	    --load \
+	    -f docker/$${dockerfile} \
+	    . \
+    && docker run --name tmp-build-dcinja --platform=$${platform} dcinja:$${tag} \
+	&& docker cp tmp-build-dcinja:/app/dcinja $${dist}/dcinja \
+	&& docker rm tmp-build-dcinja
+
+# release multi-platform by buildx and push it to dockerhub
+# buildx support push single tag name with multiple platform, and allow user to pull image by specific platform arch.
+fn-release-dcinja = \
+    export tag="$(1)" \
+    && export dockerfile="$(2)" \
+    \
+	&& docker buildx build \
+	    --platform=$(ALL_PLATFORM) \
+	    --tag falldog/dcinja:$${tag} \
+	    --push \
+	    -f docker/$${dockerfile} \
+	    .
+
+fn-compress-file = \
+    export lib="$(1)" \
+    && export platform="$(2)" \
+    && export suffix="$(3)" \
+    \
+    && cd $(DIST_DIR)/$${lib}/$${platform} \
+    && tar cvzf $(RELEASE_DIR)/dcinja-$(VERSION).$${suffix}.tar.gz dcinja
+
 
 test-docker: build
-	# linux-amd64
-	$(call fn-test-dcinja-linux-amd64,ubuntu:20.04)
-	$(call fn-test-dcinja-linux-amd64,ubuntu:18.04)
-	$(call fn-test-dcinja-linux-amd64,ubuntu:16.04)
-	$(call fn-test-dcinja-linux-amd64,debian:stretch)
-	$(call fn-test-dcinja-linux-amd64,debian:buster)
+	### glibc
+	# param: (1) libc (2) platform (3) image name
+	$(call fn-test-dcinja,glibc,linux/amd64,ubuntu:20.04)
+	$(call fn-test-dcinja,glibc,linux/amd64,ubuntu:18.04)
+	$(call fn-test-dcinja,glibc,linux/amd64,ubuntu:16.04)
+	$(call fn-test-dcinja,glibc,linux/amd64,debian:stretch)
+	$(call fn-test-dcinja,glibc,linux/amd64,debian:buster)
 
 
-	# alpine
+	### alpine
 	# need build the image include libstd++
-	docker build -t dcinja/alpine-3.9 --build-arg=VER=3.9 -f docker/Dockerfile.alpine-tester-base .
-	docker build -t dcinja/alpine-3.10 --build-arg=VER=3.10 -f docker/Dockerfile.alpine-tester-base .
-	docker build -t dcinja/alpine-3.11 --build-arg=VER=3.11 -f docker/Dockerfile.alpine-tester-base .
-	docker build -t dcinja/alpine-3.12 --build-arg=VER=3.12 -f docker/Dockerfile.alpine-tester-base .
-
-	$(call fn-test-dcinja-alpine,dcinja/alpine-3.9)
-	$(call fn-test-dcinja-alpine,dcinja/alpine-3.10)
-	$(call fn-test-dcinja-alpine,dcinja/alpine-3.11)
-	$(call fn-test-dcinja-alpine,dcinja/alpine-3.12)
+	docker build --platform=linux/amd64 -t dcinja/alpine-3.9 --build-arg=VER=3.9 -f docker/Dockerfile.alpine-tester-base .
+	docker build --platform=linux/amd64 -t dcinja/alpine-3.10 --build-arg=VER=3.10 -f docker/Dockerfile.alpine-tester-base .
+	docker build --platform=linux/amd64 -t dcinja/alpine-3.11 --build-arg=VER=3.11 -f docker/Dockerfile.alpine-tester-base .
+	docker build --platform=linux/amd64 -t dcinja/alpine-3.12 --build-arg=VER=3.12 -f docker/Dockerfile.alpine-tester-base .
+	# param: (1) libc (2) platform (3) image name
+	$(call fn-test-dcinja,alpine,linux/amd64,dcinja/alpine-3.9)
+	$(call fn-test-dcinja,alpine,linux/amd64,dcinja/alpine-3.10)
+	$(call fn-test-dcinja,alpine,linux/amd64,dcinja/alpine-3.11)
+	$(call fn-test-dcinja,alpine,linux/amd64,dcinja/alpine-3.12)
 
 
 # only focus on alpine environment
@@ -39,23 +117,17 @@ build: build-linux build-alpine
 
 
 build-linux:
-	docker build -t dcinja:linux-amd64 -f docker/Dockerfile.linux-amd64 .
-	# linux-amd64
-	mkdir -p ${DIST_DIR}/linux-amd64
-	rm -f ${DIST_DIR}/linux-amd64/dcinja
-	docker run --name tmp-build-dcinja dcinja:linux-amd64
-	docker cp tmp-build-dcinja:/app/dcinja ${DIST_DIR}/linux-amd64/dcinja
-	docker rm tmp-build-dcinja
+	# param: (1) libc (2) platform (3) tag name (4) Dockerfile name
+	$(call fn-build-dcinja,glibc,linux/amd64,linux-amd64,Dockerfile.linux)
+	$(call fn-build-dcinja,glibc,linux/arm64,linux-arm64,Dockerfile.linux)
+	$(call fn-build-dcinja,glibc,linux/arm/v7,linux-arm-v7,Dockerfile.linux)
 
 
 build-alpine:
-	docker build -t dcinja:alpine -f docker/Dockerfile.alpine .
-	# alpine
-	mkdir -p ${DIST_DIR}/alpine
-	rm -f ${DIST_DIR}/alpine/dcinja
-	docker run --name tmp-build-dcinja dcinja:alpine
-	docker cp tmp-build-dcinja:/app/dcinja ${DIST_DIR}/alpine/dcinja
-	docker rm tmp-build-dcinja
+	# param: (1) libc (2) platform (3) tag name (4) Dockerfile name
+	$(call fn-build-dcinja,alpine,linux/amd64,alpine-amd64,Dockerfile.alpine)
+	$(call fn-build-dcinja,alpine,linux/arm64,alpine-arm64,Dockerfile.alpine)
+	$(call fn-build-dcinja,alpine,linux/arm/v7,alpine-arm-v7,Dockerfile.alpine)
 
 
 build-dev:
@@ -64,17 +136,19 @@ build-dev:
 
 release: build
 	mkdir -p ${RELEASE_DIR}/
-	cd ${DIST_DIR}/alpine \
-		&& tar cvzf ${RELEASE_DIR}/dcinja-${VERSION}.alpine.tar.gz dcinja
-	cd ${DIST_DIR}/linux-amd64 \
-		&& tar cvzf ${RELEASE_DIR}/dcinja-${VERSION}.linux-amd64.tar.gz dcinja
+	# param: (1) libc (2) platform (3) filename suffix
+	$(call fn-compress-file,glibc,linux/amd64,linux-amd64)
+	$(call fn-compress-file,glibc,linux/arm64,linux-arm64)
+	$(call fn-compress-file,glibc,linux/arm/v7,linux-arm-v7)
+	$(call fn-compress-file,alpine,linux/amd64,alpine-amd64)
+	$(call fn-compress-file,alpine,linux/arm64,alpine-arm64)
+	$(call fn-compress-file,alpine,linux/arm/v7,alpine-arm-v7)
 
-publish-dockerhub: build
-	docker image tag dcinja:linux-amd64 falldog/dcinja:latest
-	docker image tag dcinja:linux-amd64 falldog/dcinja:${VERSION}
-	docker push falldog/dcinja:latest
-	docker push falldog/dcinja:${VERSION}
-	docker image tag dcinja:alpine falldog/dcinja:latest-alpine
-	docker image tag dcinja:alpine falldog/dcinja:${VERSION}-alpine
-	docker push falldog/dcinja:latest-alpine
-	docker push falldog/dcinja:${VERSION}-alpine
+
+publish-dockerhub:
+	# param: (1) tag (2) dockerfile
+	$(call fn-release-dcinja,$(VERSION),Dockerfile.linux)
+	$(call fn-release-dcinja,$(VERSION)-alpine,Dockerfile.alpine)
+	$(call fn-release-dcinja,latest,Dockerfile.linux)
+	$(call fn-release-dcinja,latest-alpine,Dockerfile.alpine)
+

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 include Makefile.base
 
-VERSION = 1.4
+VERSION = 1.4.1
 RELEASE_DIR = $(abspath ${DIST_DIR}/release/${VERSION})
 
 fn-test-dcinja-linux-amd64 = docker run --rm -v `pwd`/${DIST_DIR}:/app $(1) sh -c "echo \"Normal: {{ name }}\" | /app/linux-amd64/dcinja -j '{\"name\": \"$(1)\"}'"

--- a/docker/Dockerfile.alpine
+++ b/docker/Dockerfile.alpine
@@ -1,4 +1,4 @@
-FROM alpine:3.9 as alpine-builder
+FROM alpine:3.9 AS alpine-builder
 LABEL maintainer=falldog
 
 RUN apk update \

--- a/docker/Dockerfile.alpine-test
+++ b/docker/Dockerfile.alpine-test
@@ -1,5 +1,5 @@
 # dcinja
-FROM dcinja:alpine as dcinja
+FROM dcinja:alpine AS dcinja
 
 # alpine test environment
 FROM python:3.9.4-alpine3.13

--- a/docker/Dockerfile.example.ubuntu-20
+++ b/docker/Dockerfile.example.ubuntu-20
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04 as dcinja-downloader
+FROM ubuntu:20.04 AS dcinja-downloader
 
 RUN apt-get update \
     && apt-get install -y \

--- a/docker/Dockerfile.linux
+++ b/docker/Dockerfile.linux
@@ -1,4 +1,4 @@
-FROM debian:buster AS linux-amd64-builder
+FROM debian:buster AS linux-builder
 LABEL maintainer=falldog
 
 RUN apt-get update \
@@ -14,6 +14,6 @@ RUN make -f Makefile.base
 
 
 FROM debian:buster
-COPY --from=linux-amd64-builder /code/dist/dcinja /app/
+COPY --from=linux-builder /code/dist/dcinja /app/
 WORKDIR /app
 ENTRYPOINT [ "/app/dcinja" ]

--- a/docker/Dockerfile.linux-amd64
+++ b/docker/Dockerfile.linux-amd64
@@ -1,4 +1,4 @@
-FROM debian:buster as linux-amd64-builder
+FROM debian:buster AS linux-amd64-builder
 LABEL maintainer=falldog
 
 RUN apt-get update \


### PR DESCRIPTION
Fix Issue #2 

Support platform arch as below
* linux/amd64
* linux/arm64
* linux/arm/v7

User could keep original behavior to copy dcinja file from docker `COPY --from`. It will follow the target image arch to fetch correct arch type file.